### PR TITLE
add functionality to configure dock/station settings

### DIFF
--- a/custom_components/robovac_mqtt/__init__.py
+++ b/custom_components/robovac_mqtt/__init__.py
@@ -8,7 +8,7 @@ from .EufyClean import EufyClean
 
 from .constants.hass import DOMAIN, VACS, DEVICES
 
-PLATFORMS = [Platform.VACUUM, Platform.BUTTON, Platform.SENSOR]
+PLATFORMS = [Platform.VACUUM, Platform.BUTTON, Platform.SENSOR, Platform.SELECT, Platform.NUMBER, Platform.SWITCH]
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/robovac_mqtt/controllers/SharedConnect.py
+++ b/custom_components/robovac_mqtt/controllers/SharedConnect.py
@@ -13,7 +13,11 @@ from ..proto.cloud.clean_param_pb2 import (CleanExtent, CleanParamRequest,
                                            MopMode)
 from ..proto.cloud.control_pb2 import (ModeCtrlRequest, ModeCtrlResponse,
                                        SelectRoomsClean)
-from ..proto.cloud.station_pb2 import (StationRequest, ManualActionCmd, StationResponse)
+from ..proto.cloud.station_pb2 import (
+    StationRequest, ManualActionCmd, StationResponse, AutoActionCfg,
+    WashCfg, DryCfg, CollectDustCfg, CollectDustCfgV2
+)
+from ..proto.cloud.common_pb2 import Switch
 from ..proto.cloud.error_code_pb2 import ErrorCode
 from ..proto.cloud.work_status_pb2 import WorkStatus
 from ..utils import decode, encode, encode_message
@@ -257,6 +261,21 @@ class SharedConnect(Base):
             return 0
         except Exception as error:
             _LOGGER.error(error)
+
+    async def get_auto_action_cfg(self):
+        try:
+            value = decode(StationResponse, self.robovac_data['STATION_STATUS'])
+            return value.auto_cfg_status
+        except Exception as e:
+            _LOGGER.error(f"Error getting auto action cfg: {e}")
+            return None
+
+    async def set_auto_action_cfg(self, cfg: dict):
+        try:
+            value = encode(StationRequest, {'auto_cfg': cfg})
+            return await self.send_command({self.dps_map['GO_HOME']: value})
+        except Exception as e:
+            _LOGGER.error(f"Error setting auto action cfg: {e}")
 
     async def set_clean_speed(self, clean_speed: EUFY_CLEAN_CLEAN_SPEED):
         try:

--- a/custom_components/robovac_mqtt/number.py
+++ b/custom_components/robovac_mqtt/number.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .constants.hass import DEVICES, DOMAIN, VACS
+from .controllers.SharedConnect import SharedConnect
+from .proto.cloud.station_pb2 import (
+    AutoActionCfg,
+    WashCfg,
+    CollectDustCfgV2,
+)
+from .proto.cloud.common_pb2 import Numerical
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    entities = []
+    for device_id, device in hass.data[DOMAIN][DEVICES].items():
+        _LOGGER.info("Adding number entities for %s", device_id)
+        
+        # Wash Frequency Value
+        def set_wash_freq_value(cfg, val):
+            cfg.wash.wash_freq.time_or_area.value = int(val)
+
+        entities.append(DockNumberEntity(
+            device,
+            "wash_frequency_value",
+            "Wash Frequency Value (Time)",
+            15, 25, 1, # Min, Max, Step
+            lambda cfg: cfg.wash.wash_freq.time_or_area.value,
+            set_wash_freq_value,
+            "mdi:clock-time-four-outline"
+        ))
+
+    async_add_entities(entities)
+
+
+class DockNumberEntity(NumberEntity):
+    def __init__(
+        self,
+        device: SharedConnect,
+        id_suffix: str,
+        name: str,
+        min_val: float,
+        max_val: float,
+        step_val: float,
+        getter: Any,
+        setter: Any,
+        icon: str = None,
+    ) -> None:
+        super().__init__()
+        self.vacuum = device
+        self._attr_unique_id = f"{device.device_id}_{id_suffix}"
+        self._attr_name = name
+        self._attr_native_min_value = min_val
+        self._attr_native_max_value = max_val
+        self._attr_native_step = step_val
+        self._getter = getter
+        self._setter = setter
+        if icon:
+            self._attr_icon = icon
+        
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.device_id)},
+            name=device.device_model_desc,
+            manufacturer="Eufy",
+            model=device.device_model,
+        )
+        self._attr_native_value = None
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    async def async_added_to_hass(self):
+        await self.async_update()
+        self.async_write_ha_state()
+        try:
+            self.vacuum.add_listener(self._handle_update)
+        except Exception:
+            _LOGGER.exception("Failed to add update listener for %s", self._attr_unique_id)
+
+    async def async_will_remove_from_hass(self):
+        try:
+            if hasattr(self.vacuum, "_update_listeners"):
+                try:
+                    self.vacuum._update_listeners.remove(self._handle_update)
+                except ValueError:
+                    pass
+        except Exception:
+             _LOGGER.exception("Failed to remove update listener for %s", self._attr_unique_id)
+    
+    async def _handle_update(self):
+        await self.async_update()
+        self.async_write_ha_state()
+
+    async def async_update(self):
+        try:
+            cfg = await self.vacuum.get_auto_action_cfg()
+            if cfg:
+                try:
+                    self._attr_native_value = self._getter(cfg)
+                except Exception:
+                    pass
+        except Exception as e:
+            _LOGGER.error(f"Error updating {self._attr_name}: {e}")
+
+    async def async_set_native_value(self, value: float) -> None:
+        try:
+            cfg = await self.vacuum.get_auto_action_cfg()
+            if not cfg:
+                cfg = AutoActionCfg()
+            
+            self._setter(cfg, value)
+            
+            from google.protobuf.json_format import MessageToDict
+            cfg_dict = MessageToDict(cfg, preserving_proto_field_name=True)
+            await self.vacuum.set_auto_action_cfg(cfg_dict)
+            
+            self._attr_native_value = value
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.error(f"Error setting {self._attr_name}: {e}")

--- a/custom_components/robovac_mqtt/proto/cloud/station.proto
+++ b/custom_components/robovac_mqtt/proto/cloud/station.proto
@@ -32,6 +32,7 @@ message CollectDustCfgV2 {    // 集尘配置新版协议
         enum Value {
             BY_TASK = 0;  // 按次数
             BY_TIME = 1;  // 按时间
+            SMART = 2;    // 智能托管
         }
         Value value = 1;
 

--- a/custom_components/robovac_mqtt/select.py
+++ b/custom_components/robovac_mqtt/select.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .constants.hass import DEVICES, DOMAIN, VACS
+from .controllers.SharedConnect import SharedConnect
+from .proto.cloud.station_pb2 import (
+    AutoActionCfg,
+    WashCfg,
+    DryCfg,
+    CollectDustCfg,
+    CollectDustCfgV2,
+    Duration,
+)
+from .proto.cloud.common_pb2 import Switch
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    entities = []
+    for device_id, device in hass.data[DOMAIN][DEVICES].items():
+        _LOGGER.info("Adding select entities for %s", device_id)
+        
+        # Wash Frequency Mode
+        def set_wash_freq_mode(cfg, val):
+            cfg.wash.wash_freq.mode = WashCfg.BackwashFreq.Mode.ByPartition if val == "ByRoom" else WashCfg.BackwashFreq.Mode.ByTime
+
+        entities.append(DockSelectEntity(
+            device,
+            "wash_frequency_mode",
+            "Wash Frequency Mode",
+            ["ByRoom", "ByTime"],
+            lambda cfg: "ByRoom" if cfg.wash.wash_freq.mode == WashCfg.BackwashFreq.Mode.ByPartition else "ByTime",
+            set_wash_freq_mode,
+            "mdi:calendar-sync"
+        ))
+
+        # Dry Duration
+        def set_dry_duration(cfg, val):
+            cfg.dry.duration.level = ["2h", "3h", "4h"].index(val)
+
+        entities.append(DockSelectEntity(
+            device,
+            "dry_duration",
+            "Dry Duration",
+            ["2h", "3h", "4h"],
+             lambda cfg: "3h" if not cfg.HasField("dry") else ("2h" if cfg.dry.duration.level == 0 else ("3h" if cfg.dry.duration.level == 1 else "4h")),
+            set_dry_duration,
+            "mdi:timer-sand"
+        ))
+
+        # Collect Dust Mode (V2)
+        def get_collect_dust_mode(cfg):
+            # Check for value 2 (SMART)
+            if cfg.collectdust_v2.mode.value == 2:
+                return "Smart"
+            # Fallback to BY_TASK as "Smart" (legacy check)
+            elif cfg.collectdust_v2.mode.value == CollectDustCfgV2.Mode.Value.BY_TASK:
+                return "Smart" 
+            elif cfg.collectdust_v2.mode.value == CollectDustCfgV2.Mode.Value.BY_TIME:
+                return f"{cfg.collectdust_v2.mode.time} min"
+            return "Smart"
+
+        def set_collect_dust_mode(cfg, val):
+            if val == "Smart":
+                cfg.collectdust_v2.mode.value = 2 # SMART
+            else:
+                try:
+                    minutes = int(val.split(' ')[0])
+                    cfg.collectdust_v2.mode.value = CollectDustCfgV2.Mode.Value.BY_TIME
+                    cfg.collectdust_v2.mode.time = minutes
+                except ValueError:
+                    _LOGGER.error(f"Invalid collect dust mode value: {val}")
+
+        entities.append(DockSelectEntity(
+            device,
+            "collect_dust_mode",
+            "Auto Empty Mode",
+            ["Smart", "15 min", "30 min", "45 min", "60 min"],
+            get_collect_dust_mode,
+            set_collect_dust_mode,
+            "mdi:delete-restore"
+        ))
+
+    async_add_entities(entities)
+
+
+class DockSelectEntity(SelectEntity):
+    def __init__(
+        self,
+        device: SharedConnect,
+        id_suffix: str,
+        name: str,
+        options: list[str],
+        getter: Any,
+        setter: Any,
+        icon: str = None,
+    ) -> None:
+        super().__init__()
+        self.vacuum = device
+        self._attr_unique_id = f"{device.device_id}_{id_suffix}"
+        self._attr_name = name
+        self._attr_options = options
+        self._getter = getter
+        self._setter = setter
+        if icon:
+            self._attr_icon = icon
+        
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.device_id)},
+            name=device.device_model_desc,
+            manufacturer="Eufy",
+            model=device.device_model,
+        )
+        self._attr_current_option = None
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    async def async_added_to_hass(self):
+        await self.async_update()
+        self.async_write_ha_state()
+        try:
+            self.vacuum.add_listener(self._handle_update)
+        except Exception:
+            _LOGGER.exception("Failed to add update listener for %s", self._attr_unique_id)
+
+    async def async_will_remove_from_hass(self):
+        try:
+            if hasattr(self.vacuum, "_update_listeners"):
+                try:
+                    self.vacuum._update_listeners.remove(self._handle_update)
+                except ValueError:
+                    pass
+        except Exception:
+             _LOGGER.exception("Failed to remove update listener for %s", self._attr_unique_id)
+    
+    async def _handle_update(self):
+        await self.async_update()
+        self.async_write_ha_state()
+
+    async def async_update(self):
+        try:
+            cfg = await self.vacuum.get_auto_action_cfg()
+            if cfg:
+                try:
+                    self._attr_current_option = self._getter(cfg)
+                except Exception:
+                    pass
+        except Exception as e:
+            _LOGGER.error(f"Error updating {self._attr_name}: {e}")
+
+    async def async_select_option(self, option: str) -> None:
+        try:
+            cfg = await self.vacuum.get_auto_action_cfg()
+            if not cfg:
+                cfg = AutoActionCfg()
+            
+            self._setter(cfg, option)
+            
+            from google.protobuf.json_format import MessageToDict
+            cfg_dict = MessageToDict(cfg, preserving_proto_field_name=True)
+            await self.vacuum.set_auto_action_cfg(cfg_dict)
+            
+            self._attr_current_option = option
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.error(f"Error setting {self._attr_name}: {e}")

--- a/custom_components/robovac_mqtt/switch.py
+++ b/custom_components/robovac_mqtt/switch.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .constants.hass import DEVICES, DOMAIN, VACS
+from .controllers.SharedConnect import SharedConnect
+from .proto.cloud.station_pb2 import (
+    AutoActionCfg,
+    CollectDustCfgV2,
+    WashCfg,
+)
+from .proto.cloud.common_pb2 import Switch
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    entities = []
+    for device_id, device in hass.data[DOMAIN][DEVICES].items():
+        _LOGGER.info("Adding switch entities for %s", device_id)
+        
+        # Detergent - Removed per user request
+
+        # Collect Dust Enable (V2)
+        def set_collect_dust_switch(cfg, val):
+            cfg.collectdust_v2.sw.value = bool(val)
+
+        entities.append(DockSwitchEntity(
+            device,
+            "collect_dust_switch",
+            "Auto Empty",
+            lambda cfg: cfg.collectdust_v2.sw.value,
+            set_collect_dust_switch,
+            "mdi:delete-restore"
+        ))
+
+        # Auto Mop Washing
+        def set_auto_mop_washing(cfg, val):
+            cfg.wash.cfg = WashCfg.Cfg.STANDARD if val else WashCfg.Cfg.CLOSE
+        
+        entities.append(DockSwitchEntity(
+            device,
+            "auto_mop_washing_switch",
+            "Auto Mop Washing",
+            lambda cfg: cfg.wash.cfg == WashCfg.Cfg.STANDARD,
+            set_auto_mop_washing,
+            "mdi:water-sync"
+        ))
+
+    async_add_entities(entities)
+
+
+class DockSwitchEntity(SwitchEntity):
+    def __init__(
+        self,
+        device: SharedConnect,
+        id_suffix: str,
+        name: str,
+        getter: Any,
+        setter: Any,
+        icon: str = None,
+    ) -> None:
+        super().__init__()
+        self.vacuum = device
+        self._attr_unique_id = f"{device.device_id}_{id_suffix}"
+        self._attr_name = name
+        self._getter = getter
+        self._setter = setter
+        if icon:
+            self._attr_icon = icon
+        
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.device_id)},
+            name=device.device_model_desc,
+            manufacturer="Eufy",
+            model=device.device_model,
+        )
+        self._attr_is_on = None
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    async def async_added_to_hass(self):
+        await self.async_update()
+        self.async_write_ha_state()
+        try:
+            self.vacuum.add_listener(self._handle_update)
+        except Exception:
+            _LOGGER.exception("Failed to add update listener for %s", self._attr_unique_id)
+
+    async def async_will_remove_from_hass(self):
+        try:
+            if hasattr(self.vacuum, "_update_listeners"):
+                try:
+                    self.vacuum._update_listeners.remove(self._handle_update)
+                except ValueError:
+                    pass
+        except Exception:
+             _LOGGER.exception("Failed to remove update listener for %s", self._attr_unique_id)
+    
+    async def _handle_update(self):
+        await self.async_update()
+        self.async_write_ha_state()
+
+    async def async_update(self):
+        try:
+            cfg = await self.vacuum.get_auto_action_cfg()
+            if cfg:
+                try:
+                    self._attr_is_on = self._getter(cfg)
+                except Exception:
+                    pass
+        except Exception as e:
+            _LOGGER.error(f"Error updating {self._attr_name}: {e}")
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self._set_state(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self._set_state(False)
+
+    async def _set_state(self, state: bool) -> None:
+        try:
+            cfg = await self.vacuum.get_auto_action_cfg()
+            if not cfg:
+                cfg = AutoActionCfg()
+            
+            self._setter(cfg, state)
+            
+            from google.protobuf.json_format import MessageToDict
+            cfg_dict = MessageToDict(cfg, preserving_proto_field_name=True)
+            await self.vacuum.set_auto_action_cfg(cfg_dict)
+            
+            self._attr_is_on = state
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.error(f"Error setting {self._attr_name}: {e}")


### PR DESCRIPTION
## New Features
new dock configuration features added to the Eufy Clean Home Assistant integration. These changes allow you to fully control your station's wash, dry, and auto-empty settings directly from Home Assistant, mirroring the official app's functionality.

### Configuration Entities
All new entities are grouped under the **Configuration** category of your device.
#### Select Entities
| Entity Name | Options | Icon | Description |
| :--- | :--- | :--- | :--- |
| **Wash Frequency Mode** | `ByRoom`, `ByTime` | `mdi:calendar-sync` | Choose whether to wash the mop after cleaning a specific number of rooms or after a set duration. |
| **Dry Duration** | `2h`, `3h`, `4h` | `mdi:timer-sand` | Set the duration for drying the mop. |
| **Auto Empty Mode** | `Smart`, `15 min`, `30 min`, `45 min`, `60 min` | `mdi:delete-restore` | Configure how often the dust bin is emptied. `Smart` corresponds to the intelligent mode. |
#### Number Entities
| Entity Name | Range | Icon | Description |
| :--- | :--- | :--- | :--- |
| **Wash Frequency Value** | `15` - `25` min | `mdi:clock-time-four-outline` | Set the duration interval for mop washing when mode is set to `ByTime`. |
#### Switch Entities
| Entity Name | Icon | Description |
| :--- | :--- | :--- |
| **Auto Empty** | `mdi:delete-restore` | Enable or disable the auto-empty feature. |
| **Auto Mop Washing** | `mdi:water-sync` | Enable or disable automatic mop washing. |
